### PR TITLE
Fix requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,5 @@ feedparser
 scikit-learn
 pandas
 joblib
+httpx
+python-jose


### PR DESCRIPTION
## Summary
- add `httpx` and `python-jose` to requirements

## Testing
- `pip install -r requirements.txt`
- `pytest -q` *(fails: Firebase ENV setup missing)*

------
https://chatgpt.com/codex/tasks/task_e_68407aa9dbf0832ca46ac606b6c666c8