### PR TITLE
Fix feedback reasons field validation

### DIFF
--- a/app/schemas/feedback_schema.py
+++ b/app/schemas/feedback_schema.py
@@ -4,5 +4,5 @@ from typing import List, Literal, Optional
 class FeedbackRequest(BaseModel):
     post_id: str
     sentiment: Literal["like", "dislike"]
-    reasons: List[int] = Field(default_factory=list, max_length=10)
+    reasons: List[int] = Field(default_factory=list, max_items=10)
     comment: Optional[str] = Field(default=None, max_length=100)


### PR DESCRIPTION
## Summary
- use `max_items` list validator for `reasons` field in FeedbackRequest

## Testing
- `pytest -q` *(fails: cannot import name 'save_feedback_to_firestore')*

------
https://chatgpt.com/codex/tasks/task_e_68407ba5abb0832c823fb68077e15002